### PR TITLE
auto-generated page alias is wrong, when changelanguage is installed

### DIFF
--- a/dca/tl_page.php
+++ b/dca/tl_page.php
@@ -73,7 +73,7 @@ class tl_page_changelanguage extends Backend
 	{
 		if ($this->Input->get('act') == 'edit')
 		{
-			$objPage = $this->getPageDetails($dc->id);
+			$objPage = $this->getPageDetails($dc->activeRecord->id);
 
 			if ($objPage->type == 'root' && $objPage->fallback)
 			{


### PR DESCRIPTION
If you have folder-url activated in the Contao general frontend settings, Contao saves a wrong page alias into tl_page, when creating a new subpage.
