### PR TITLE
ChangeLanguage::translateArticles did not work

### DIFF
--- a/ChangeLanguage.php
+++ b/ChangeLanguage.php
@@ -44,20 +44,22 @@ class ChangeLanguage extends Controller
 		{
 			global $objPage;
 
-			$currentArticle = $this->Database->prepare("SELECT id, languageMain FROM tl_article WHERE pid = ? AND alias = ?")->execute( $objPage->id, $arrParams['url']['articles'] );
+			// get gurrent article properties
+			$currentArticle = $this->Database->prepare("SELECT id, languageMain FROM tl_article WHERE pid = ? AND alias = ?")->execute($objPage->id, $arrParams['url']['articles']);
 
-			// if languageMain zero, search for other article referencing current article
+			// if languageMain is zero, search for other article referencing current article
 			if ($currentArticle->languageMain == 0)
 			{
-				$otherArticle = $this->Database->prepare("SELECT id, alias FROM tl_article WHERE languageMain = ?")->execute( $currentArticle->id );
+				$otherArticle = $this->Database->prepare("SELECT id, alias FROM tl_article WHERE languageMain = ?")->execute($currentArticle->id);
 			}
 			else
-				$otherArticle = $this->Database->prepare("SELECT id, alias FROM tl_article WHERE id = ?")->execute( $currentArticle->languageMain );
+			{
+				$otherArticle = $this->Database->prepare("SELECT id, alias FROM tl_article WHERE id = ?")->execute($currentArticle->languageMain);
 			}
 
-			if ($objArticle->numRows)
+			if ($otherArticle->numRows)
 			{
-				$arrParams['url']['articles'] = $objArticle->alias ? $objArticle->alias : $objArticle->id;
+				$arrParams['url']['articles'] = $otherArticle->alias ? $otherArticle->alias : $otherArticle->id;
 			}
 		}
 


### PR DESCRIPTION
There were 3 errors in ChangeLanguage::translateArticles:
- the function accessed the wrong array parameter of $arrParams
- the SQL statement was erroneous (WHERE WHERE)
- the function was unable to switch from the main language to another language 
