### PR TITLE
Doppelslash in Domainvariable wenn TL_PATH nicht leer ist.

### DIFF
--- a/ModuleChangeLanguage.php
+++ b/ModuleChangeLanguage.php
@@ -155,7 +155,7 @@ class ModuleChangelanguage extends Module
             		$domain .= TL_PATH;
             	}
 
-				$domain . '/';
+				$domain .= '/';
             }
 
         	$blnDirectFallback = true;


### PR DESCRIPTION
Mein Contao Installation (3.1.3) liegt nicht im DocumentRoot (http://www.domain.de/path/).
Wenn zwei unterschiedliche Domains für die Sprachen gewählt werden und die Fremd-Domain Hauptsprache gesetzt wird, dann hat er beim wechseln der Sprache ein Doppelslash in die URL geschrieben (http://www.domain.de//path/). Ich hoffe das behebt das Problem.
