### PR TITLE
Unterdrückung des hreflang Tags bei nicht direkt korrespondierenden S…

### DIFF
--- a/library/Terminal42/ChangeLanguage/Helper/AlternateLinks.php
+++ b/library/Terminal42/ChangeLanguage/Helper/AlternateLinks.php
@@ -60,7 +60,9 @@ class AlternateLinks
      */
     public function addFromNavigationItem(NavigationItem $item, UrlParameterBag $urlParameterBag)
     {
-        $this->add($item->getLanguageTag(), $item->getHref($urlParameterBag), $item->getTitle());
+        if( $item->isDirectFallback() ) {
+            $this->add($item->getLanguageTag(), $item->getHref($urlParameterBag), $item->getTitle());
+        }
     }
 
     /**


### PR DESCRIPTION
…eiten

Wenn die Option "Sprachen ohne direkte Hauptsprache ausblenden" nicht aktiviert ist, wird als Umschaltseite die nächste verfügbare Elternseite genommen. Dafür darf aber kein hreflang-Tag gesetzt werden, da diese Seite nicht wieder zurückweist, sondern ihre eigene alternative Sprachversion hat.