### PR TITLE
Wrap registration of DataContainer listeners in a try catch block.

### DIFF
--- a/library/Terminal42/ChangeLanguage/EventListener/CallbackSetupListener.php
+++ b/library/Terminal42/ChangeLanguage/EventListener/CallbackSetupListener.php
@@ -71,9 +71,16 @@ class CallbackSetupListener
         if (array_key_exists($table, self::$listeners)) {
             foreach (self::$listeners[$table] as $class) {
 
-                /** @var AbstractTableListener $listener */
-                $listener = new $class($table);
-                $listener->register();
+                try {
+                    /** @var AbstractTableListener $listener */
+                    $listener = new $class($table);
+                    $listener->register();
+                } catch (\InvalidArgumentException $e) {
+                    // An invalid argument exception will be thrown
+                    // if the given table belongs to a disabled
+                    // extension. In this case, do nothing.
+                    continue;
+                }
             }
         }
     }


### PR DESCRIPTION
This prevents an uncatched InvalidArgumentException from happening, which is being thrown when you disable an extension like tl_calendar through the settings tab in the contao backend.

Fixes #82.