### PR TITLE
#98 Workaround/Fix for cases without parent page

### DIFF
--- a/library/Terminal42/ChangeLanguage/EventListener/BackendView/ParentChildViewListener.php
+++ b/library/Terminal42/ChangeLanguage/EventListener/BackendView/ParentChildViewListener.php
@@ -47,7 +47,15 @@ class ParentChildViewListener extends AbstractViewListener
             return null;
         }
 
-        $pageId = $this->current->pid ? $this->current->getRelated('pid')->jumpTo : $this->current->jumpTo;
+        if ($this->current->pid) {
+            try {
+                $parent = $this->current->getRelated('pid');
+            } catch (\Exception $e) {
+                $parent = null;
+            }
+        }
+
+        $pageId = $parent ? $parent->jumpTo : $this->current->jumpTo;
 
         return PageModel::findWithDetails($pageId);
     }


### PR DESCRIPTION
In combination with the news4ward module, there is the `pid` set, but it is not a page and there is also no `pid` relation. This catched the exception and let's you still edit the entry.