### PR TITLE
Ensure the button is added only once

### DIFF
--- a/library/Terminal42/ChangeLanguage/EventListener/BackendView/AbstractViewListener.php
+++ b/library/Terminal42/ChangeLanguage/EventListener/BackendView/AbstractViewListener.php
@@ -79,6 +79,7 @@ abstract class AbstractViewListener extends AbstractTableListener
 
         if (($page = $this->getCurrentPage()) !== null
             && count($languages = $this->getAvailableLanguages($page)) !== 0
+            && !array_key_exists('switchLanguage', $GLOBALS['TL_DCA'][$this->table]['list']['global_operations'])
         ) {
             $GLOBALS['TL_CSS'][] = 'system/modules/changelanguage/assets/backend.css';
 


### PR DESCRIPTION
When adding the button twice, the callback will get converted to an array and therefore will be uncallable later on.
So we now simply abstain from overwriting any pre-existing button.