### PR TITLE
Fix: Custom Order when using `Custom language texts` not working in a special case

### DIFF
--- a/library/Terminal42/ChangeLanguage/Helper/LanguageText.php
+++ b/library/Terminal42/ChangeLanguage/Helper/LanguageText.php
@@ -98,8 +98,8 @@ class LanguageText
         $languages = array_keys($this->map);
 
         usort($items, function (NavigationItem $a, NavigationItem $b) use ($languages) {
-            $key1 = array_search(strtolower($a->getNormalizedLanguage()), $languages, true);
-            $key2 = array_search(strtolower($b->getNormalizedLanguage()), $languages, true);
+            $key1 = array_search(strtolower($a->getLanguageTag()), $languages, true);
+            $key2 = array_search(strtolower($b->getLanguageTag()), $languages, true);
 
             return ($key1 < $key2) ? -1 : 1;
         });

--- a/library/Terminal42/ChangeLanguage/Tests/Helper/LanguageText/LanguageTextWithMapEntriesTest.php
+++ b/library/Terminal42/ChangeLanguage/Tests/Helper/LanguageText/LanguageTextWithMapEntriesTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * changelanguage Extension for Contao Open Source CMS
+ *
+ * @copyright  Copyright (c) CTS GmbH
+ * @author     CTS GmbH <info@cts-media.eu>
+ * @license    http://opensource.org/licenses/lgpl-3.0.html LGPL
+ * @link       http://github.com/terminal42/contao-changelanguage
+ */
+
+namespace Terminal42\ChangeLanguage\Tests\Helper;
+
+use Contao\PageModel;
+use Terminal42\ChangeLanguage\Helper\LanguageText;
+use Terminal42\ChangeLanguage\Navigation\NavigationItem;
+use Terminal42\ChangeLanguage\Tests\ContaoTestCase;
+
+class LanguageTextWithMapEntriesTest extends ContaoTestCase
+{
+    /**
+     * @var LanguageText
+     */
+    private $languageText;
+
+    /**
+     * @var NavigationItem[]
+     */
+    private $items;
+
+    /**
+     * @var array this defined both the displayed text AND the sorting order
+     */
+    private $map = [
+        'en'    => 'International',
+        'de-CH' => 'Switzerland (German)',
+        'de'    => 'Germany',
+        'fr-FR' => 'France',
+        'pl'    => 'Poland',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->languageText = new LanguageText($this->map);
+
+        $fooComId = $this->createRootPage('foo.com', 'en');
+        $barChId = $this->createRootPage('bar.ch', 'de-CH');
+        $bazDeId = $this->createRootPage('baz.de', 'de');
+        $helloFrId = $this->createRootPage('hello.fr', 'fr-FR');
+        $worldPlId = $this->createRootPage('world.pl', 'pl');
+
+        $fooCom = PageModel::findById($fooComId);
+        $barCh = PageModel::findById($barChId);
+        $bazDe = PageModel::findById($bazDeId);
+        $helloFr = PageModel::findById($helloFrId);
+        $worldPl = PageModel::findById($worldPlId);
+
+        //items do not get added in "correct" order on purpose to test the sorting
+        $this->items[] = new NavigationItem($barCh);
+        $this->items[] = new NavigationItem($worldPl);
+        $this->items[] = new NavigationItem($fooCom);
+        $this->items[] = new NavigationItem($helloFr);
+        $this->items[] = new NavigationItem($bazDe);
+    }
+
+    public function testOrderNavigationItemsResultsInExpectedOrder()
+    {
+        $this->languageText->orderNavigationItems($this->items);
+        $keys = array_keys($this->map);
+
+        foreach ($this->items as $item) {
+            //items order should be equal to the order in the map which was passed to LanguageText
+            $this->assertEquals(array_shift($keys), $item->getLanguageTag());
+        }
+    }
+
+    private function createRootPage($dns, $language)
+    {
+        return $this->query("
+            INSERT INTO tl_page 
+            (type, title, dns, language, published) 
+            VALUES 
+            ('root', 'foobar', '$dns', '$language', '1')
+        ");
+    }
+}


### PR DESCRIPTION
We noticed that the custom order based on the order of `Custom language texts` does not work if you use something like `de-CH` or `en-US`

If you leave out the country code then it works (no change has been done on that).

The Reason this fails is because the method `getNormalizedLanguage()` returns something like `de_CH` or `en_US` - which leads to array_search not finding the entry in `$languages` and thus returning false even though it shouldn't.

I've choosen the current way of doing it because I didn't want to change the method `getNormalizedLanguage()` itself because it is also used elsewhere (when setting some css classes for the frontend which could cause problems for people who rely on this for something).

Edit: Notice I am not talking about it being case-sensitive - the code does strtolower anyways - the problem is dash `-` (In Contao) vs underscore `_` (from `getNormalizedLanguage()`)