### PR TITLE
[RTM] add page title to duplicateMainLanguage Exception

### DIFF
--- a/languages/en/default.xlf
+++ b/languages/en/default.xlf
@@ -7,7 +7,7 @@
     <file original="languages/en/default.xlf" source-language="en" datatype="plaintext">
         <body>
             <trans-unit id="MSC.duplicateMainLanguage">
-                <source>This main language record is already assigned to %s.</source>
+                <source>The selected page is already assigned to "%s" in the main language.</source>
             </trans-unit>
             <trans-unit id="MSC.noMainLanguage">
                 <source>Main language missing</source>

--- a/languages/en/default.xlf
+++ b/languages/en/default.xlf
@@ -7,7 +7,7 @@
     <file original="languages/en/default.xlf" source-language="en" datatype="plaintext">
         <body>
             <trans-unit id="MSC.duplicateMainLanguage">
-                <source>This main language record already has an assigment.</source>
+                <source>This main language record is already assigned to %s.</source>
             </trans-unit>
             <trans-unit id="MSC.noMainLanguage">
                 <source>Main language missing</source>

--- a/library/Terminal42/ChangeLanguage/EventListener/DataContainer/PageFieldsListener.php
+++ b/library/Terminal42/ChangeLanguage/EventListener/DataContainer/PageFieldsListener.php
@@ -83,22 +83,15 @@ class PageFieldsListener
             );
 
 
-            if (count($duplicates) > 0) {
+            if (null !== $duplicates) {
 
-                $properties = [];
+                $labels = [];
 
                 foreach ($duplicates as $duplicate) {
-                    $properties[] = [
-                      'id' => $duplicate->id,
-                      'title' => $duplicate->title,
-                    ];
+                    $labels[] = sprintf('%s (ID %s)', $duplicate->id, $duplicate->title);
                 }
 
-                $properties = array_map(function($property) {
-                    return sprintf('%s (ID %s)', $property['title'], $property['id']);
-                }, $properties);
-
-                throw new \RuntimeException(sprintf($GLOBALS['TL_LANG']['MSC']['duplicateMainLanguage'], implode(', ', $properties)));
+                throw new \RuntimeException(sprintf($GLOBALS['TL_LANG']['MSC']['duplicateMainLanguage'], implode(', ', $labels)));
             }
         }
 

--- a/library/Terminal42/ChangeLanguage/EventListener/DataContainer/PageFieldsListener.php
+++ b/library/Terminal42/ChangeLanguage/EventListener/DataContainer/PageFieldsListener.php
@@ -73,7 +73,7 @@ class PageFieldsListener
             $currentPage = PageModel::findWithDetails($dc->id);
             $childIds = \Database::getInstance()->getChildRecords($currentPage->rootId, 'tl_page');
 
-            $duplicates = PageModel::countBy(
+            $duplicates = PageModel::findBy(
                 [
                     'tl_page.id IN ('.implode(',', $childIds).')',
                     'tl_page.languageMain=?',
@@ -82,8 +82,9 @@ class PageFieldsListener
                 [$value, $dc->id]
             );
 
-            if ($duplicates > 0) {
-                throw new \RuntimeException($GLOBALS['TL_LANG']['MSC']['duplicateMainLanguage']);
+            if (count($duplicates) > 0) {
+                $titles = $duplicates->fetchEach('title');
+                throw new \RuntimeException(sprintf($GLOBALS['TL_LANG']['MSC']['duplicateMainLanguage'], implode(', ', $titles)));
             }
         }
 

--- a/library/Terminal42/ChangeLanguage/EventListener/DataContainer/PageFieldsListener.php
+++ b/library/Terminal42/ChangeLanguage/EventListener/DataContainer/PageFieldsListener.php
@@ -82,9 +82,23 @@ class PageFieldsListener
                 [$value, $dc->id]
             );
 
+
             if (count($duplicates) > 0) {
-                $titles = $duplicates->fetchEach('title');
-                throw new \RuntimeException(sprintf($GLOBALS['TL_LANG']['MSC']['duplicateMainLanguage'], implode(', ', $titles)));
+
+                $properties = [];
+
+                foreach ($duplicates as $duplicate) {
+                    $properties[] = [
+                      'id' => $duplicate->id,
+                      'title' => $duplicate->title,
+                    ];
+                }
+
+                $properties = array_map(function($property) {
+                    return sprintf('%s (ID %s)', $property['title'], $property['id']);
+                }, $properties);
+
+                throw new \RuntimeException(sprintf($GLOBALS['TL_LANG']['MSC']['duplicateMainLanguage'], implode(', ', $properties)));
             }
         }
 


### PR DESCRIPTION
Hi there,

as discussed on IRC the other day, this PR improves the duplicateMainLanguage error message. It simply outputs the title of the page that is already assigned as main language equivalent to the current page. 

I am not sure, whether it should be the title (can be rather long + multiple pages might have the same title) or the alias (could be even longer, especially if you use folder urls, but would be unique). The ID however would be short and unique, but still quite abstract. 

Hence I think the title should be the best choice. 

Ready for comments :) 

Cheers