### PR TITLE
Add microdata to <nav>

### DIFF
--- a/templates/mod_changelanguage.html5
+++ b/templates/mod_changelanguage.html5
@@ -1,6 +1,6 @@
 
 <!-- indexer::stop -->
-<nav class="<?php echo $this->class; ?> block"<?php echo $this->cssID; ?><?php if ($this->style): ?> style="<?php echo $this->style; ?>"<?php endif; ?>>
+<nav class="<?php echo $this->class; ?> block"<?php echo $this->cssID; ?><?php if ($this->style): ?> style="<?php echo $this->style; ?>"<?php endif; ?> itemscope="" itemtype="http://schema.org/SiteNavigationElement">
 <?php if ($this->headline): ?>
 
 <<?php echo $this->hl; ?>><?php echo $this->headline; ?></<?php echo $this->hl; ?>>


### PR DESCRIPTION
The default navigation list template 'nav_default.html5' of Contao is adding microdata to the list items (itemprop url and itemprop name).

Currently these Microdata inside the language links are hierarchically connected with the itemtype "WebPage" of the < body > element. This is wrong, because now all language links are interpreted as names and urls of the document itself. You can check this wrong connection and behaviour when testing any Contao site with installed ChangeLanguage in the microdata testing tool at https://search.google.com/structured-data/testing-tool

This PR is adding the correct itemtype "SiteNavigationElement" to the wrapping < nav > Element of the language links to correct the wrong connection to the body itemtype.