### PR TITLE
Use w50 class for select widget

### DIFF
--- a/library/Terminal42/ChangeLanguage/EventListener/DataContainer/ParentTableListener.php
+++ b/library/Terminal42/ChangeLanguage/EventListener/DataContainer/ParentTableListener.php
@@ -50,6 +50,7 @@ class ParentTableListener
             'eval' => [
                 'includeBlankOption' => true,
                 'blankOptionLabel' => &$GLOBALS['TL_LANG'][$this->table]['isMaster'],
+                'tl_class' => 'w50',
             ],
             'save_callback' => [function ($value, DataContainer $dc) {
                 $this->validateMaster($value, $dc);


### PR DESCRIPTION
Something that has been bothering me for a while :). The `w50` class is missing for the `select` widget for news archives etc., creating an necessarily wide select widget in the back end, which looks off by comparison. The `languageMain` select widget also uses `w50`.