### PR TITLE
Do not reset languageMain

### DIFF
--- a/library/Terminal42/ChangeLanguage/EventListener/DataContainer/PageOperationListener.php
+++ b/library/Terminal42/ChangeLanguage/EventListener/DataContainer/PageOperationListener.php
@@ -22,24 +22,8 @@ class PageOperationListener
     {
         $GLOBALS['TL_DCA']['tl_page']['config']['oncopy_callback'][] = $this->selfCallback('onCopy');
         $GLOBALS['TL_DCA']['tl_page']['config']['oncut_callback'][] = $this->selfCallback('onCut');
-        $GLOBALS['TL_DCA']['tl_page']['config']['onsubmit_callback'][] = $this->selfCallback('onSubmit');
         $GLOBALS['TL_DCA']['tl_page']['config']['ondelete_callback'][] = $this->selfCallback('onDelete');
         $GLOBALS['TL_DCA']['tl_page']['config']['onundo_callback'][] = $this->selfCallback('onUndo');
-    }
-
-    /**
-     * Handles submitting a page and resets tl_page.languageMain if necessary.
-     *
-     * @param DataContainer $dc
-     */
-    public function onSubmit(DataContainer $dc)
-    {
-        if ('root' === $dc->activeRecord->type
-            && $dc->activeRecord->fallback
-            && (!$dc->activeRecord->languageRoot || null === PageModel::findByPk($dc->activeRecord->languageRoot))
-        ) {
-            $this->resetPageAndChildren($dc->id);
-        }
     }
 
     /**


### PR DESCRIPTION
Consider the following scenario, where you set up a page like this:

* `example.org/en` (fallback)
* `example.org/de`

The site contains a lot of pages in both website roots and the pages in the `de` have their respective page in the main page tree (`en`) assigned.

However, later on it is decided to switch to a domain based setup, not using the language parameter in the URL:

* `example.org` (en)
* `example.de` (de)

But when you do that `terminal42/contao-changelanguage` currently resets the `languageMain` assignment for _all_ pages in the `example.de` website tree, meaning that the painstaking work of assigning all the pages the respective main page of the fallback language is lost.

I do not think the extension should do that at all. Under normal circumstances, there is never a use case where you would want this to happen, is there?