### PR TITLE
Add doNotCopy

### DIFF
--- a/dca/tl_page.php
+++ b/dca/tl_page.php
@@ -24,7 +24,7 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['languageMain'] = array
     'label'                   => &$GLOBALS['TL_LANG']['tl_page']['languageMain'],
     'exclude'                 => true,
     'inputType'               => 'pageTree',
-    'eval'                    => array('fieldType'=>'radio', 'multiple'=>false, 'rootNodes'=>[0], 'tl_class'=>'w50 clr'),
+    'eval'                    => array('fieldType'=>'radio', 'multiple'=>false, 'rootNodes'=>[0], 'tl_class'=>'w50 clr', 'doNoCopy'=>true),
     'sql'                     => "int(10) unsigned NOT NULL default '0'",
     'load_callback'           => [['Terminal42\ChangeLanguage\EventListener\DataContainer\PageFieldsListener', 'onLoadLanguageMain']],
     'save_callback'           => [['Terminal42\ChangeLanguage\EventListener\DataContainer\PageFieldsListener', 'onSaveLanguageMain']],

--- a/library/Terminal42/ChangeLanguage/EventListener/DataContainer/LanguageMainTrait.php
+++ b/library/Terminal42/ChangeLanguage/EventListener/DataContainer/LanguageMainTrait.php
@@ -29,6 +29,7 @@ trait LanguageMainTrait
                 'blankOptionLabel' => &$GLOBALS['TL_LANG'][$this->getTable()]['languageMain'][2],
                 'chosen' => true,
                 'tl_class' => 'w50',
+                'doNotCopy' => true,
             ],
             'sql' => "int(10) unsigned NOT NULL default '0'",
             'relation' => ['type' => 'hasOne', 'table' => $this->getTable()],


### PR DESCRIPTION
If you copy a `tl_news` entry for example which is already assigned to another news in the main language, its `tl_news.languageMain` value will be copied as well. This leads to an ambiguous state for the alternative of a news article in other languages. And in the back end the selected **Master article** will show _Unknown option_ (as you cannot select a news article from the main language which is already assigned to another news article).

Same is basically true for pages as well. This PR adjusts the DCA of `tl_page` as well as `LanguageMainTrait::addLanguageMainField` and adds `'doNotCopy' => true` to the `eval` of the `languageMain` field.