### PR TITLE
Fix undefined array key warning under php8

### DIFF
--- a/src/EventListener/BackendView/ParentChildViewListener.php
+++ b/src/EventListener/BackendView/ParentChildViewListener.php
@@ -134,6 +134,6 @@ class ParentChildViewListener extends AbstractViewListener
 
         Controller::loadDataContainer($table);
 
-        return '' !== (string) ($GLOBALS['TL_DCA'][$table]['config']['ptable'] ?? '');
+        return !empty($GLOBALS['TL_DCA'][$table]['config']['ptable']);
     }
 }

--- a/src/EventListener/BackendView/ParentChildViewListener.php
+++ b/src/EventListener/BackendView/ParentChildViewListener.php
@@ -134,6 +134,6 @@ class ParentChildViewListener extends AbstractViewListener
 
         Controller::loadDataContainer($table);
 
-        return '' !== (string) $GLOBALS['TL_DCA'][$table]['config']['ptable'];
+        return '' !== (string) ($GLOBALS['TL_DCA'][$table]['config']['ptable'] ?? '');
     }
 }


### PR DESCRIPTION
Fixes `Warning: Undefined array key "ptable"` warning under PHP8:

```
ErrorException:
Warning: Undefined array key "ptable"

  at vendor/terminal42/contao-changelanguage/src/EventListener/BackendView/ParentChildViewListener.php:137
  at Terminal42\ChangeLanguage\EventListener\BackendView\ParentChildViewListener->hasParent()
     (vendor/terminal42/contao-changelanguage/src/EventListener/BackendView/ParentChildViewListener.php:57)
  at Terminal42\ChangeLanguage\EventListener\BackendView\ParentChildViewListener->getAvailableLanguages(object(PageModel))
     (vendor/terminal42/contao-changelanguage/src/EventListener/BackendView/AbstractViewListener.php:73)
  at Terminal42\ChangeLanguage\EventListener\BackendView\AbstractViewListener->onLoad(object(DC_Table))
     (vendor/terminal42/contao-changelanguage/src/EventListener/BackendView/AbstractViewListener.php:44)
  at Terminal42\ChangeLanguage\EventListener\BackendView\AbstractViewListener->Terminal42\ChangeLanguage\EventListener\BackendView\{closure}(object(DC_Table))
     (vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Table.php:207)
  at Contao\DC_Table->__construct('tl_news', array('tables' => array('tl_news_archive', 'tl_news', 'tl_news_feed', 'tl_content', 'tl_news_category'), 'table' => array('Contao\\TableWizard', 'importTable'), 'list' => array('Contao\\ListWizard', 'importList')))
     (vendor/contao/core-bundle/src/Resources/contao/classes/Backend.php:415)
  at Contao\Backend->getBackendModule('news', null)
     (vendor/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php:167)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:158)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:80)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:201)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:43)
```