### PR TITLE
Do not copy languageMain and languageRoot

### DIFF
--- a/contao/dca/tl_page.php
+++ b/contao/dca/tl_page.php
@@ -14,7 +14,7 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['languageMain'] = array
     'label'                   => &$GLOBALS['TL_LANG']['tl_page']['languageMain'],
     'exclude'                 => true,
     'inputType'               => 'pageTree',
-    'eval'                    => array('fieldType'=>'radio', 'multiple'=>false, 'rootNodes'=>[0], 'tl_class'=>'w50 clr'),
+    'eval'                    => array('fieldType'=>'radio', 'multiple'=>false, 'rootNodes'=>[0], 'tl_class'=>'w50 clr', 'doNotCopy' => true),
     'sql'                     => "int(10) unsigned NOT NULL default '0'",
     'load_callback'           => [['Terminal42\ChangeLanguage\EventListener\DataContainer\PageFieldsListener', 'onLoadLanguageMain']],
     'save_callback'           => [['Terminal42\ChangeLanguage\EventListener\DataContainer\PageFieldsListener', 'onSaveLanguageMain']],
@@ -26,7 +26,7 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['languageRoot'] = array
     'exclude'                 => true,
     'inputType'               => 'select',
     'options_callback'        => array('Terminal42\ChangeLanguage\EventListener\DataContainer\PageFieldsListener', 'onLanguageRootOptions'),
-    'eval'                    => array('includeBlankOption'=>true, 'blankOptionLabel'=>&$GLOBALS['TL_LANG']['tl_page']['languageRoot'][2], 'tl_class'=>'w50'),
+    'eval'                    => array('includeBlankOption'=>true, 'blankOptionLabel'=>&$GLOBALS['TL_LANG']['tl_page']['languageRoot'][2], 'tl_class'=>'w50', 'doNotCopy' => true),
     'sql'                     => "int(10) unsigned NOT NULL default '0'"
 );
 

--- a/src/EventListener/DataContainer/LanguageMainTrait.php
+++ b/src/EventListener/DataContainer/LanguageMainTrait.php
@@ -22,6 +22,7 @@ trait LanguageMainTrait
                 'blankOptionLabel' => &$GLOBALS['TL_LANG'][$this->getTable()]['languageMain'][2],
                 'chosen' => true,
                 'tl_class' => 'w50',
+                'doNotCopy' => true,
             ],
             'sql' => "int(10) unsigned NOT NULL default '0'",
             'relation' => ['type' => 'hasOne', 'table' => $this->getTable()],


### PR DESCRIPTION
When you copy an event for instance, the `languageMain` value should not be copied, since it might end up being copied to the _main_ calendar and then you end up with a main event that still has a `languageMain` reference to another main event.