### PR TITLE
Set table name for child query

### DIFF
--- a/src/EventListener/BackendView/ParentChildViewListener.php
+++ b/src/EventListener/BackendView/ParentChildViewListener.php
@@ -37,7 +37,8 @@ class ParentChildViewListener extends AbstractViewListener
             }
 
             if ('paste' === Input::get('act') || ('edit' === Input::get('act') && 'tl_content' === $this->getTable())) {
-                $this->current = $class::findOneBy(['id=(SELECT pid FROM '.$this->getTable().' WHERE id=?)'], [$this->dataContainer->id]);
+                $t = $class::getTable();
+                $this->current = $class::findOneBy(["$t.id=(SELECT pid FROM ".$this->getTable().' WHERE id=?)'], [$this->dataContainer->id]);
             } else {
                 $this->current = $class::findByPk($this->dataContainer->id);
             }


### PR DESCRIPTION
If you have a custom field in `tl_news` for example with `'load' => 'eager'` (or you set the existing `tl_news.author` field to `'load' => 'eager')` the following error will occur when editing the content elements of a news article for example:

```
Doctrine\DBAL\Exception\NonUniqueFieldNameException:
An exception occurred while executing 'SELECT tl_news.*, j1.`id` AS … FROM tl_news LEFT JOIN … WHERE id=(SELECT pid FROM tl_content WHERE id='42559') LIMIT 0,1':

SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous

  at vendor\doctrine\dbal\lib\Doctrine\DBAL\Driver\AbstractMySQLDriver.php:84
  at Doctrine\DBAL\Driver\AbstractMySQLDriver->convertException('An exception occurred while executing \'…\':SQLSTATE[23000]: Integrity constraint violation: 1052 Column \'id\' in where clause is ambiguous', object(Exception))
     (vendor\doctrine\dbal\lib\Doctrine\DBAL\DBALException.php:182)
  at Doctrine\DBAL\DBALException::wrapException(object(Driver), object(Exception), 'An exception occurred while executing \'…\':SQLSTATE[23000]: Integrity constraint violation: 1052 Column \'id\' in where clause is ambiguous')
     (vendor\doctrine\dbal\lib\Doctrine\DBAL\DBALException.php:159)
  at Doctrine\DBAL\DBALException::driverExceptionDuringQuery(object(Driver), object(Exception), '…', array())
     (vendor\doctrine\dbal\lib\Doctrine\DBAL\Connection.php:2226)
  at Doctrine\DBAL\Connection->handleExceptionDuringQuery(object(Exception), '…', array(), array())
     (vendor\doctrine\dbal\lib\Doctrine\DBAL\Connection.php:1313)
  at Doctrine\DBAL\Connection->executeQuery('…')
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Database\Statement.php:274)
  at Contao\Database\Statement->query()
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Database\Statement.php:248)
  at Contao\Database\Statement->execute(array('42559'))
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Model.php:1077)
  at Contao\Model::find(array('limit' => 1, 'column' => array('id=(SELECT pid FROM tl_content WHERE id=?)'), 'value' => array('42559'), 'return' => 'Model', 'table' => 'tl_news', 'offset' => 0))
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Model.php:915)
  at Contao\Model::findOneBy(array('id=(SELECT pid FROM tl_content WHERE id=?)'), array('42559'))
     (vendor\terminal42\contao-changelanguage\src\EventListener\BackendView\ParentChildViewListener.php:40)
  at Terminal42\ChangeLanguage\EventListener\BackendView\ParentChildViewListener->getCurrentPage()
     (vendor\terminal42\contao-changelanguage\src\EventListener\BackendView\AbstractViewListener.php:72)
  at Terminal42\ChangeLanguage\EventListener\BackendView\AbstractViewListener->onLoad(object(DC_Table))
     (vendor\terminal42\contao-changelanguage\src\EventListener\BackendView\AbstractViewListener.php:44)
  at Terminal42\ChangeLanguage\EventListener\BackendView\AbstractViewListener->Terminal42\ChangeLanguage\EventListener\BackendView\{closure}(object(DC_Table))
     (vendor\contao\core-bundle\src\Resources\contao\drivers\DC_Table.php:201)
…
```

This PR fixes the ambiguity issue by referencing the model's table in the condition.