### PR TITLE
Fix PHP 8 warnings

### DIFF
--- a/contao/templates/nav_dropdown.html5
+++ b/contao/templates/nav_dropdown.html5
@@ -20,9 +20,9 @@
 <?php if ($intLevel == 1 && !$blnHasActive): ?><option value="">-</option><?php endif; ?>
 <?php foreach ($this->items as $item): ?>
 <?php if ($item['isActive']): ?>
-<option class="active <?php echo $item['class']; ?>" selected><?php echo str_repeat('&nbsp;&nbsp;&nbsp;', $intLevel-1); ?><?php echo $arrLanguages[strtolower($item['link'])] ?: $item['link']; ?><?php echo $item['subitems']; ?></option>
+<option class="active <?php echo $item['class']; ?>" selected><?php echo str_repeat('&nbsp;&nbsp;&nbsp;', $intLevel-1); ?><?php echo $arrLanguages[strtolower($item['link'])] ?? $item['link']; ?><?php echo $item['subitems']; ?></option>
 <?php else: ?>
-<option <?php if ($item['class']): ?> class="<?php echo $item['class']; ?>"<?php endif; ?> value="<?php echo $item['href']; ?>"><?php echo str_repeat('&nbsp;&nbsp;&nbsp;', $intLevel-1); ?><?php echo $arrLanguages[strtolower($item['link'])] ?: $item['link']; ?><?php echo $item['subitems']; ?></option>
+<option <?php if ($item['class']): ?> class="<?php echo $item['class']; ?>"<?php endif; ?> value="<?php echo $item['href']; ?>"><?php echo str_repeat('&nbsp;&nbsp;&nbsp;', $intLevel-1); ?><?php echo $arrLanguages[strtolower($item['link'])] ?? $item['link']; ?><?php echo $item['subitems']; ?></option>
 <?php endif; ?>
 <?php endforeach; ?>
 <?php if ($intLevel == 1): ?>


### PR DESCRIPTION
Fixes PHP 8 warnings like

```
ErrorException:
Warning: Undefined array key "en_at"

  at C:\Users\fmg\www\hps-new\vendor\terminal42\contao-changelanguage\contao\templates\nav_dropdown.html5:25
```

in case you use languages or language + region combinations not known to Contao/ICU.