### PR TITLE
Fix navigation listener if bundle is not installed

### DIFF
--- a/src/EventListener/Navigation/CalendarNavigationListener.php
+++ b/src/EventListener/Navigation/CalendarNavigationListener.php
@@ -34,6 +34,10 @@ class CalendarNavigationListener extends AbstractNavigationListener
 
     protected function findCurrent(): ?CalendarEventsModel
     {
+        if (!class_exists(ContaoCalendarBundle::class)) {
+            return null;
+        }
+
         $alias = $this->getAutoItem();
 
         if ('' === $alias) {

--- a/src/EventListener/Navigation/FaqNavigationListener.php
+++ b/src/EventListener/Navigation/FaqNavigationListener.php
@@ -34,6 +34,10 @@ class FaqNavigationListener extends AbstractNavigationListener
 
     protected function findCurrent(): ?FaqModel
     {
+        if (!class_exists(ContaoFaqBundle::class)) {
+            return null;
+        }
+
         $alias = $this->getAutoItem();
 
         if ('' === $alias) {

--- a/src/EventListener/Navigation/NewsNavigationListener.php
+++ b/src/EventListener/Navigation/NewsNavigationListener.php
@@ -34,6 +34,10 @@ class NewsNavigationListener extends AbstractNavigationListener
 
     protected function findCurrent(): ?NewsModel
     {
+        if (!class_exists(ContaoNewsBundle::class)) {
+            return null;
+        }
+
         $alias = $this->getAutoItem();
 
         if ('' === $alias) {


### PR DESCRIPTION
If not all bundles like calendar, faq or news are installed you will get errors in the navigation listener

Obviously the check in the `__invoke` method is not enough because in the `ChangeLanguageModule` the hook is called directly, e.g. `Terminal42\ChangeLanguage\EventListener\Navigation\CalendarNavigationListener` > `onChangelanguageNavigation`