### PR TITLE
Add the aria-label attribute to links in the frontend module

### DIFF
--- a/contao/languages/de/default.xlf
+++ b/contao/languages/de/default.xlf
@@ -21,6 +21,9 @@
                 <source>Switch to %s</source>
                 <target>Zu %s wechseln</target>
             </trans-unit>
+            <trans-unit id="MSC.gotoLanguage">
+                <source>Zur aktuelle Seite auf %s wechseln</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/contao/languages/en/default.xlf
+++ b/contao/languages/en/default.xlf
@@ -21,6 +21,9 @@
             <trans-unit id="MSC.switchLanguageTo.1">
                 <source>Switch to %s</source>
             </trans-unit>
+            <trans-unit id="MSC.gotoLanguage">
+                <source>Go to current page in %s</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/FrontendModule/ChangeLanguageModule.php
+++ b/src/FrontendModule/ChangeLanguageModule.php
@@ -152,8 +152,7 @@ class ChangeLanguageModule extends Module
             'accesskey' => '',
             'tabindex' => '',
             'nofollow' => false,
-            'rel' => sprintf(' aria-label="%s"', sprintf($GLOBALS['TL_LANG']['MSC']['switchLanguageTo'][1], $languages[$item->getLocaleId()])),
-            'target' => ($item->isNewWindow() ? ' target="_blank"' : '').' hreflang="'.$item->getLanguageTag().'" lang="'.$item->getLanguageTag().'"',
+            'target' => ($item->isNewWindow() ? ' target="_blank"' : '').sprintf(' hreflang="%s" lang="%s" aria-label="%s"', $item->getLanguageTag(), $item->getLanguageTag(), sprintf($GLOBALS['TL_LANG']['MSC']['switchLanguageTo'][1], $languages[$item->getLocaleId()])),
             'item' => $item,
         ];
     }

--- a/src/FrontendModule/ChangeLanguageModule.php
+++ b/src/FrontendModule/ChangeLanguageModule.php
@@ -35,10 +35,7 @@ class ChangeLanguageModule extends Module
 
     private static ?AlternateLinks $alternateLinks = null;
 
-    /**
-     * @return AlternateLinks
-     */
-    public function getAlternateLinks()
+    public function getAlternateLinks(): AlternateLinks
     {
         if (null === self::$alternateLinks) {
             self::$alternateLinks = new AlternateLinks();
@@ -83,7 +80,7 @@ class ChangeLanguageModule extends Module
             $languageText = new LanguageText();
         }
 
-        $navigationFactory = new NavigationFactory($pageFinder, $languageText, $currentPage);
+        $navigationFactory = new NavigationFactory($pageFinder, $languageText, $currentPage, System::getContainer()->get('contao.intl.locales')->getLocales());
         $navigationItems = $navigationFactory->findNavigationItems($currentPage);
 
         // Do not generate module or header if there is none or only one link
@@ -135,12 +132,6 @@ class ChangeLanguageModule extends Module
      */
     protected function generateTemplateArray(NavigationItem $item, UrlParameterBag $urlParameterBag): array
     {
-        static $languages;
-
-        if (null === $languages) {
-            $languages = System::getContainer()->get('contao.intl.locales')->getLocales(null, true);
-        }
-
         return [
             'isActive' => $item->isCurrentPage(),
             'class' => 'lang-'.$item->getNormalizedLanguage().($item->isDirectFallback() ? '' : ' nofallback').($item->isCurrentPage() ? ' active' : ''),
@@ -152,8 +143,10 @@ class ChangeLanguageModule extends Module
             'accesskey' => '',
             'tabindex' => '',
             'nofollow' => false,
-            'target' => ($item->isNewWindow() ? ' target="_blank"' : '').sprintf(' hreflang="%s" lang="%s" aria-label="%s"', $item->getLanguageTag(), $item->getLanguageTag(), sprintf($GLOBALS['TL_LANG']['MSC']['switchLanguageTo'][1], $languages[$item->getLocaleId()])),
+            'rel' => ' hreflang="'.$item->getLanguageTag().'"'.(empty($item->getAriaLabel() ? '' : ' aria-label="'.$item->getAriaLabel().'"')),
+            'target' => ($item->isNewWindow() ? ' target="_blank"' : ''),
             'item' => $item,
+            'languageTag' => $item->getLanguageTag(),
         ];
     }
 

--- a/src/FrontendModule/ChangeLanguageModule.php
+++ b/src/FrontendModule/ChangeLanguageModule.php
@@ -135,6 +135,12 @@ class ChangeLanguageModule extends Module
      */
     protected function generateTemplateArray(NavigationItem $item, UrlParameterBag $urlParameterBag): array
     {
+        static $languages;
+
+        if (null === $languages) {
+            $languages = System::getContainer()->get('contao.intl.locales')->getLocales(null, true);
+        }
+
         return [
             'isActive' => $item->isCurrentPage(),
             'class' => 'lang-'.$item->getNormalizedLanguage().($item->isDirectFallback() ? '' : ' nofallback').($item->isCurrentPage() ? ' active' : ''),
@@ -146,6 +152,7 @@ class ChangeLanguageModule extends Module
             'accesskey' => '',
             'tabindex' => '',
             'nofollow' => false,
+            'rel' => sprintf(' aria-label="%s"', sprintf($GLOBALS['TL_LANG']['MSC']['switchLanguageTo'][1], $languages[$item->getLocaleId()])),
             'target' => ($item->isNewWindow() ? ' target="_blank"' : '').' hreflang="'.$item->getLanguageTag().'" lang="'.$item->getLanguageTag().'"',
             'item' => $item,
         ];

--- a/src/Navigation/NavigationFactory.php
+++ b/src/Navigation/NavigationFactory.php
@@ -14,12 +14,14 @@ class NavigationFactory
     private PageFinder $pageFinder;
     private LanguageText $languageText;
     private PageModel $currentPage;
+    private array $locales = [];
 
-    public function __construct(PageFinder $pageFinder, LanguageText $languageText, PageModel $currentPage)
+    public function __construct(PageFinder $pageFinder, LanguageText $languageText, PageModel $currentPage, array $locales = [])
     {
         $this->pageFinder = $pageFinder;
         $this->languageText = $languageText;
         $this->currentPage = $currentPage;
+        $this->locales = $locales;
     }
 
     /**
@@ -39,6 +41,14 @@ class NavigationFactory
         );
 
         foreach ($navigationItems as $item) {
+            if (isset($this->locales[$item->getLocaleId()])) {
+                $item->setAriaLabel(
+                    $item->isDirectFallback()
+                        ? sprintf($GLOBALS['TL_LANG']['MSC']['gotoLanguage'], $this->locales[$item->getLocaleId()])
+                        : sprintf($GLOBALS['TL_LANG']['MSC']['switchLanguageTo'][1], $this->locales[$item->getLocaleId()])
+                );
+            }
+
             if (!$item->hasTargetPage()) {
                 try {
                     $item->setTargetPage(

--- a/src/Navigation/NavigationItem.php
+++ b/src/Navigation/NavigationItem.php
@@ -13,6 +13,7 @@ class NavigationItem
     private PageModel $rootPage;
     private ?PageModel $targetPage = null;
     private string $linkLabel;
+    private ?string $ariaLabel = null;
     private ?bool $newWindow = null;
     private bool $isDirectFallback = false;
     private bool $isCurrentPage = false;
@@ -64,6 +65,16 @@ class NavigationItem
     public function setLabel(string $label): void
     {
         $this->linkLabel = $label;
+    }
+
+    public function getAriaLabel(): ?string
+    {
+        return $this->ariaLabel;
+    }
+
+    public function setAriaLabel(?string $ariaLabel): void
+    {
+        $this->ariaLabel = $ariaLabel;
     }
 
     public function getTargetPage(): ?PageModel


### PR DESCRIPTION
This pull request will automatically add the `aria-label` attribute to the language switch links in the frontend modules:

```
<a href="…" class="lang-fr" hreflang="fr" lang="fr" aria-label="Zu Französisch - français wechseln">F</a>
```