### PR TITLE
Fix an 'Invalid parameter number' error in the parent table listener

### DIFF
--- a/src/EventListener/DataContainer/ParentTableListener.php
+++ b/src/EventListener/DataContainer/ParentTableListener.php
@@ -76,7 +76,7 @@ class ParentTableListener
                 WHERE jumpTo IN ('.implode(',', $associated).') AND master=0
                 ORDER BY title
             ')
-            ->execute($dc->activeRecord->language)
+            ->execute()
         ;
 
         while ($result->next()) {


### PR DESCRIPTION
The argument causes a `SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens` error.