### PR TITLE
Support auto_item attribute in UrlParameterBag

### DIFF
--- a/src/EventListener/Navigation/CalendarNavigationListener.php
+++ b/src/EventListener/Navigation/CalendarNavigationListener.php
@@ -20,7 +20,7 @@ class CalendarNavigationListener extends AbstractNavigationListener
 {
     protected function getUrlKey(): string
     {
-        return 'events';
+        return isset($GLOBALS['TL_CONFIG']['useAutoItem']) ? 'events' : 'auto_item';
     }
 
     protected function findCurrent(): ?CalendarEventsModel

--- a/src/EventListener/Navigation/FaqNavigationListener.php
+++ b/src/EventListener/Navigation/FaqNavigationListener.php
@@ -20,7 +20,7 @@ class FaqNavigationListener extends AbstractNavigationListener
 {
     protected function getUrlKey(): string
     {
-        return 'items';
+        return isset($GLOBALS['TL_CONFIG']['useAutoItem']) ? 'items' : 'auto_item';
     }
 
     protected function findCurrent(): ?FaqModel

--- a/src/EventListener/Navigation/NewsNavigationListener.php
+++ b/src/EventListener/Navigation/NewsNavigationListener.php
@@ -20,7 +20,7 @@ class NewsNavigationListener extends AbstractNavigationListener
 {
     protected function getUrlKey(): string
     {
-        return 'items';
+        return in_array('items', $GLOBALS['TL_AUTO_ITEM'] ?? []) ? 'items' : 'auto_item';
     }
 
     protected function findCurrent(): ?NewsModel

--- a/src/EventListener/Navigation/NewsNavigationListener.php
+++ b/src/EventListener/Navigation/NewsNavigationListener.php
@@ -20,7 +20,7 @@ class NewsNavigationListener extends AbstractNavigationListener
 {
     protected function getUrlKey(): string
     {
-        return in_array('items', $GLOBALS['TL_AUTO_ITEM'] ?? []) ? 'items' : 'auto_item';
+        return isset($GLOBALS['TL_CONFIG']['useAutoItem']) ? 'items' : 'auto_item';
     }
 
     protected function findCurrent(): ?NewsModel

--- a/src/Navigation/UrlParameterBag.php
+++ b/src/Navigation/UrlParameterBag.php
@@ -105,17 +105,8 @@ class UrlParameterBag
             return null;
         }
 
-        if (isset($attributes['auto_item'])) {
-            throw new \RuntimeException('Do not set auto_item parameter');
-        }
-
-        // Contao 5 always uses auto_item
-        if (!\array_key_exists('useAutoItem', $GLOBALS['TL_CONFIG'])) {
-            $key = key($attributes);
-            $auto_item = $attributes[$key];
-            unset($attributes[$key]);
-        } elseif ($GLOBALS['TL_CONFIG']['useAutoItem']) {
-            $auto_item = array_intersect_key($attributes, array_flip((array) ($GLOBALS['TL_AUTO_ITEM'] ?? [])));
+        if ($GLOBALS['TL_CONFIG']['useAutoItem'] ?? true) {
+            $auto_item = array_intersect_key($attributes, array_flip((array) array_merge($GLOBALS['TL_AUTO_ITEM'] ?? [], ['auto_item'])));
 
             switch (\count($auto_item)) {
                 case 0:

--- a/src/Navigation/UrlParameterBag.php
+++ b/src/Navigation/UrlParameterBag.php
@@ -106,7 +106,7 @@ class UrlParameterBag
         }
 
         if ($GLOBALS['TL_CONFIG']['useAutoItem'] ?? true) {
-            $auto_item = array_intersect_key($attributes, array_flip((array) array_merge($GLOBALS['TL_AUTO_ITEM'] ?? [], ['auto_item'])));
+            $auto_item = array_intersect_key($attributes, array_flip(array_merge((array) ($GLOBALS['TL_AUTO_ITEM'] ?? []), ['auto_item'])));
 
             switch (\count($auto_item)) {
                 case 0:


### PR DESCRIPTION
This is a proof of concept to fix #225 while not causing the issue described in https://github.com/contao/contao/issues/5983

I think this is the correct approach as in Contao 5 there is no `items` parameter anymore so we have to use `auto_item` instead.

If we agree on this, the other listeners have to be changed as well and the tests need to be adapted.