### PR TITLE
Fix sorting of custom language texts

### DIFF
--- a/src/Helper/LanguageText.php
+++ b/src/Helper/LanguageText.php
@@ -74,8 +74,8 @@ class LanguageText
         usort(
             $items,
             static function (NavigationItem $a, NavigationItem $b) use ($languages) {
-                $key1 = array_search(strtolower($a->getLanguageTag()), $languages, true);
-                $key2 = array_search(strtolower($b->getLanguageTag()), $languages, true);
+                $key1 = array_search(strtolower($a->getLocaleId()), $languages, true);
+                $key2 = array_search(strtolower($b->getLocaleId()), $languages, true);
 
                 return $key1 <=> $key2;
             },

--- a/tests/Helper/LanguageTextTest.php
+++ b/tests/Helper/LanguageTextTest.php
@@ -38,14 +38,14 @@ class LanguageTextTest extends ContaoTestCase
         $map = [
             'en' => 'International',
             'de' => 'Germany',
-            'de-CH' => 'Switzerland (German)',
+            'de_CH' => 'Switzerland (German)',
         ];
 
         $languageText = new LanguageText($map);
 
         $this->assertTrue($languageText->has('en'));
         $this->assertTrue($languageText->has('de'));
-        $this->assertTrue($languageText->has('de-CH'));
+        $this->assertTrue($languageText->has('de_CH'));
         $this->assertFalse($languageText->has('fr'));
     }
 
@@ -78,9 +78,9 @@ class LanguageTextTest extends ContaoTestCase
     {
         $map = [
             'en' => 'International',
-            'de-CH' => 'Switzerland (German)',
+            'de_CH' => 'Switzerland (German)',
             'de' => 'Germany',
-            'fr-FR' => 'France',
+            'fr_FR' => 'France',
             'pl' => 'Poland',
         ];
 
@@ -88,10 +88,10 @@ class LanguageTextTest extends ContaoTestCase
 
         // items do not get added in "correct" order on purpose to test the sorting
         $items = [];
-        $items[] = new NavigationItem($this->createRootPage('bar.ch', 'de-CH'));
+        $items[] = new NavigationItem($this->createRootPage('bar.ch', 'de_CH'));
         $items[] = new NavigationItem($this->createRootPage('world.pl', 'pl'));
         $items[] = new NavigationItem($this->createRootPage('foo.com', 'en'));
-        $items[] = new NavigationItem($this->createRootPage('hello.fr', 'fr-FR'));
+        $items[] = new NavigationItem($this->createRootPage('hello.fr', 'fr_FR'));
         $items[] = new NavigationItem($this->createRootPage('baz.de', 'de'));
 
         $languageText->orderNavigationItems($items);
@@ -99,7 +99,7 @@ class LanguageTextTest extends ContaoTestCase
 
         foreach ($items as $i => $item) {
             // items order should be equal to the order in the map which was passed to LanguageText
-            $this->assertSame($keys[$i], $item->getLanguageTag());
+            $this->assertSame($keys[$i], $item->getLocaleId());
         }
     }
 
@@ -110,13 +110,13 @@ class LanguageTextTest extends ContaoTestCase
         /** @var array<NavigationItem> $items */
         $items = [
             new NavigationItem($this->createRootPage('foo.com', 'en')),
-            new NavigationItem($this->createRootPage('bar.ch', 'de-CH')),
+            new NavigationItem($this->createRootPage('bar.ch', 'de_CH')),
         ];
 
         $languageText->orderNavigationItems($items);
 
-        $this->assertSame('en', $items[0]->getLanguageTag());
-        $this->assertSame('de-CH', $items[1]->getLanguageTag());
+        $this->assertSame('en', $items[0]->getLocaleId());
+        $this->assertSame('de_CH', $items[1]->getLocaleId());
     }
 
     public function testIsCreatedFromOptionWizard(): void


### PR DESCRIPTION
~~will provide some more context soon. 😎~~

The map in `LanguageText` contains all entries from the module settings (when set, otherwise it's empty):
https://github.com/terminal42/contao-changelanguage/blob/0a2ee69601a12cb3b69064997670f30b189c275b/src/Helper/LanguageText.php#L72

in my case, the list looks like this:

```
array:22 [▼
  0 => "en"
  1 => "en_us"
  2 => "en_au"
  3 => "de_at"
  4 => "nl_be"
  5 => "en_ca"
  6 => "cs_cz"
  7 => "da_dk"
  8 => "fr_fr"
  9 => "fi_fi"
  10 => "de_de"
  11 => "en_in"
  12 => "it_it"
  13 => "nl_nl"
  14 => "no_no"
  15 => "pl_pl"
  16 => "fr_ch"
  17 => "it_ch"
  18 => "de_ch"
  19 => "es_es"
  20 => "sv_se"
  21 => "en_gb"
]
```

The navigation items get build with the language on page root:
https://github.com/terminal42/contao-changelanguage/blob/0a2ee69601a12cb3b69064997670f30b189c275b/src/Navigation/NavigationFactory.php#L92-L98

which is accordingly to the backend in ISO-639 format (with `_`):

<img width="601" alt="Bildschirmfoto 2023-11-29 um 19 30 57" src="https://github.com/terminal42/contao-changelanguage/assets/754921/0572b2b4-4d65-462b-84a9-da3ec47a1f9a">

---

To fix the ordering issue, we need to use the ICU locale ID as well:

https://github.com/terminal42/contao-changelanguage/blob/0a2ee69601a12cb3b69064997670f30b189c275b/src/Language.php#L36-L47

which I adjusted in 93de99d97f28af7d20416b257c283a4890eb01d9.

Update: I've adjusted the tests accordingly in 3115ae40441b7468fddb0e1f13d6253e57c7b695.