### PR TITLE
Fix the URL generation when the page has "index" alias and expects no parameters

### DIFF
--- a/src/Navigation/NavigationItem.php
+++ b/src/Navigation/NavigationItem.php
@@ -163,7 +163,13 @@ class NavigationItem
         }
 
         try {
-            $href = $targetPage->getAbsoluteUrl($urlParameterBag->generateParameters());
+            $parameters = $urlParameterBag->generateParameters();
+
+            if ($parameters === '/') {
+                $parameters = null;
+            }
+
+            $href = $targetPage->getAbsoluteUrl($parameters);
         } catch (ExceptionInterface $e) {
             if (!$catch) {
                 throw $e;


### PR DESCRIPTION
@aschempp I am not entirely sure if this fix is correct, but we can discuss it when you're back.