### PR TITLE
Fix type hint

### DIFF
--- a/src/Helper/LabelCallback.php
+++ b/src/Helper/LabelCallback.php
@@ -55,7 +55,7 @@ class LabelCallback
     /**
      * @return mixed
      */
-    private function executeCallback(callable $callback, array $args)
+    private function executeCallback(callable|array $callback, array $args)
     {
         // Support Contao's getInstance() method when callback is an array
         if (\is_array($callback)) {

--- a/src/Helper/LabelCallback.php
+++ b/src/Helper/LabelCallback.php
@@ -53,9 +53,11 @@ class LabelCallback
     }
 
     /**
+     * @param callable|array $callback
+     *
      * @return mixed
      */
-    private function executeCallback(callable|array $callback, array $args)
+    private function executeCallback($callback, array $args)
     {
         // Support Contao's getInstance() method when callback is an array
         if (\is_array($callback)) {


### PR DESCRIPTION
Not sure if this is the only one but this currently breaks v 3.7.

```
[2024-05-21T18:31:20.113462+02:00] request.CRITICAL: Uncaught PHP Exception TypeError: "Terminal42\ChangeLanguage\Helper\LabelCallback::executeCallback(): Argument #1 ($callback) must be of type callable, array given, called in /var/www/vhosts/.../httpdocs/releases/288/vendor/terminal42/contao-changelanguage/src/Helper/LabelCallback.php on line 29" at LabelCallback.php line 58 {"exception":"[object] (TypeError(code: 0): Terminal42\\ChangeLanguage\\Helper\\LabelCallback::executeCallback(): Argument #1 ($callback) must be of type callable, array given, called in /var/www/vhosts/.../httpdocs/releases/288/vendor/terminal42/contao-changelanguage/src/Helper/LabelCallback.php on line 29 at /var/www/vhosts/.../httpdocs/releases/288/vendor/terminal42/contao-changelanguage/src/Helper/LabelCallback.php:58)"} {"request_uri":"https://.../contao?do=page&ref=WQpDYFw6","request_method":"GET"}
```