### PR TITLE
Remove SiteNavigationElement in mod_changelanguage.html5

### DIFF
--- a/contao/templates/mod_changelanguage.html5
+++ b/contao/templates/mod_changelanguage.html5
@@ -1,6 +1,6 @@
 
 <!-- indexer::stop -->
-<nav class="<?= $this->class; ?> block"<?= $this->cssID; ?><?php if ($this->style): ?> style="<?= $this->style; ?>"<?php endif; ?> itemscope="" itemtype="http://schema.org/SiteNavigationElement">
+<nav class="<?= $this->class; ?> block"<?= $this->cssID; ?><?php if ($this->style): ?> style="<?= $this->style; ?>"<?php endif; ?>>
 <?php if ($this->headline): ?>
 
 <<?= $this->hl; ?>><?= $this->headline; ?></<?= $this->hl; ?>>


### PR DESCRIPTION
Remove schema.org navigation itemprops

`itemscope="" itemtype="http://schema.org/SiteNavigationElement"`

Because this was also removed in the Contao Core:
https://github.com/contao/contao/pull/3162
https://github.com/contao/contao/pull/3163