### PR TITLE
Add missing translations

### DIFF
--- a/contao/languages/cs/default.xlf
+++ b/contao/languages/cs/default.xlf
@@ -23,6 +23,7 @@
             </trans-unit>
             <trans-unit id="MSC.gotoLanguage">
                 <source>Go to current page in %s</source>
+                <target>Přejít na aktuální stránku v %s</target>
             </trans-unit>
         </body>
     </file>

--- a/contao/languages/cs/tl_module.xlf
+++ b/contao/languages/cs/tl_module.xlf
@@ -33,6 +33,7 @@ zkratky).</target>
             </trans-unit>
             <trans-unit id="tl_module.customLanguageText.1">
                 <source>Enter the page language as key and a replacement text as value.</source>
+                <target>Jako klíč zadejte jazyk stránky a jako hodnotu náhradní text.</target>
             </trans-unit>
         </body>
     </file>

--- a/contao/languages/cs/tl_user.xlf
+++ b/contao/languages/cs/tl_user.xlf
@@ -3,12 +3,15 @@
         <body>
             <trans-unit id="tl_user.pageLanguageLabels.0">
                 <source>Fallback page titles</source>
+                <target>Náhradní názvy stránek</target>
             </trans-unit>
             <trans-unit id="tl_user.pageLanguageLabels.1">
                 <source>Select the root pages for which pages you want to show the fallback page title.</source>
+                <target>Vyberte kořenové stránky, pro které chcete zobrazit záložní název stránky.</target>
             </trans-unit>
             <trans-unit id="tl_user.changelanguage_legend">
                 <source>ChangeLanguage</source>
+                <target>ChangeLanguage</target>
             </trans-unit>
         </body>
     </file>

--- a/contao/languages/de/default.xlf
+++ b/contao/languages/de/default.xlf
@@ -23,6 +23,7 @@
             </trans-unit>
             <trans-unit id="MSC.gotoLanguage">
                 <source>Go to current page in %s</source>
+                <target>Gehe zur aktuellen Seite in %s</target>
             </trans-unit>
         </body>
     </file>

--- a/contao/languages/de/tl_module.xlf
+++ b/contao/languages/de/tl_module.xlf
@@ -32,6 +32,7 @@
             </trans-unit>
             <trans-unit id="tl_module.customLanguageText.1">
                 <source>Enter the page language as key and a replacement text as value.</source>
+                <target>Geben Sie die Seitensprache als Schlüssel und einen Ersatztext als Wert ein.</target>
             </trans-unit>
         </body>
     </file>

--- a/contao/languages/de/tl_user.xlf
+++ b/contao/languages/de/tl_user.xlf
@@ -3,12 +3,15 @@
         <body>
             <trans-unit id="tl_user.pageLanguageLabels.0">
                 <source>Fallback page titles</source>
+                <target>Ausweichseitentitel</target>
             </trans-unit>
             <trans-unit id="tl_user.pageLanguageLabels.1">
                 <source>Select the root pages for which pages you want to show the fallback page title.</source>
+                <target>Wählen Sie die Stammseiten aus, für die Sie den Ausweichseitentitel anzeigen möchten.</target>
             </trans-unit>
             <trans-unit id="tl_user.changelanguage_legend">
                 <source>ChangeLanguage</source>
+                <target>ChangeLanguage</target>
             </trans-unit>
         </body>
     </file>

--- a/contao/languages/fr/default.xlf
+++ b/contao/languages/fr/default.xlf
@@ -23,6 +23,7 @@
             </trans-unit>
             <trans-unit id="MSC.gotoLanguage">
                 <source>Go to current page in %s</source>
+                <target>Aller à la page actuelle dans %s</target>
             </trans-unit>
         </body>
     </file>

--- a/contao/languages/fr/tl_calendar.xlf
+++ b/contao/languages/fr/tl_calendar.xlf
@@ -11,6 +11,7 @@
             </trans-unit>
             <trans-unit id="tl_calendar.master.2">
                 <source>This master has already been selected for the &quot;%s&quot; calendar!</source>
+                <target>Ce maître a déjà été sélectionné pour le calendrier &quot;%s&quot;!</target>
             </trans-unit>
             <trans-unit id="tl_calendar.language.0">
                 <source>Language</source>

--- a/contao/languages/fr/tl_faq_category.xlf
+++ b/contao/languages/fr/tl_faq_category.xlf
@@ -11,6 +11,7 @@
             </trans-unit>
             <trans-unit id="tl_faq_category.master.2">
                 <source>This master has already been selected for the &quot;%s&quot; category!</source>
+                <target>Ce maître a déjà été sélectionné pour la catégorie &quot;%s&quot;!</target>
             </trans-unit>
             <trans-unit id="tl_faq_category.language.0">
                 <source>Language</source>

--- a/contao/languages/fr/tl_module.xlf
+++ b/contao/languages/fr/tl_module.xlf
@@ -33,6 +33,7 @@ abréviations).</target>
             </trans-unit>
             <trans-unit id="tl_module.customLanguageText.1">
                 <source>Enter the page language as key and a replacement text as value.</source>
+                <target>Saisissez la langue de la page comme clé et un texte de remplacement comme valeur.</target>
             </trans-unit>
         </body>
     </file>

--- a/contao/languages/fr/tl_user.xlf
+++ b/contao/languages/fr/tl_user.xlf
@@ -3,12 +3,15 @@
         <body>
             <trans-unit id="tl_user.pageLanguageLabels.0">
                 <source>Fallback page titles</source>
+                <target>Titres de page de remplacement</target>
             </trans-unit>
             <trans-unit id="tl_user.pageLanguageLabels.1">
                 <source>Select the root pages for which pages you want to show the fallback page title.</source>
+                <target>Sélectionnez les pages racines pour lesquelles vous souhaitez afficher le titre de la page de remplacement.</target>
             </trans-unit>
             <trans-unit id="tl_user.changelanguage_legend">
                 <source>ChangeLanguage</source>
+                <target>ChangeLanguage</target>
             </trans-unit>
         </body>
     </file>

--- a/contao/languages/lv/default.xlf
+++ b/contao/languages/lv/default.xlf
@@ -3,6 +3,7 @@
         <body>
             <trans-unit id="MSC.duplicateMainLanguage">
                 <source>The selected page is already assigned to &quot;%s&quot; in the main language.</source>
+                <target>Izvēlētā lapa jau ir piešķirta &quot;%s&quot; galvenajā valodā.</target>
             </trans-unit>
             <trans-unit id="MSC.noMainLanguage">
                 <source>Main language missing</source>
@@ -22,6 +23,7 @@
             </trans-unit>
             <trans-unit id="MSC.gotoLanguage">
                 <source>Go to current page in %s</source>
+                <target>Pāreja uz pašreizējo lapu %s</target>
             </trans-unit>
         </body>
     </file>

--- a/contao/languages/lv/tl_calendar.xlf
+++ b/contao/languages/lv/tl_calendar.xlf
@@ -11,6 +11,7 @@
             </trans-unit>
             <trans-unit id="tl_calendar.master.2">
                 <source>This master has already been selected for the &quot;%s&quot; calendar!</source>
+                <target>Šis meistars jau ir izvēlēts &quot;%s&quot; kalendāram!</target>
             </trans-unit>
             <trans-unit id="tl_calendar.language.0">
                 <source>Language</source>

--- a/contao/languages/lv/tl_faq_category.xlf
+++ b/contao/languages/lv/tl_faq_category.xlf
@@ -11,6 +11,7 @@
             </trans-unit>
             <trans-unit id="tl_faq_category.master.2">
                 <source>This master has already been selected for the &quot;%s&quot; category!</source>
+                <target>Šis meistars jau ir izvēlēts kategorijā &quot;%s&quot;!</target>
             </trans-unit>
             <trans-unit id="tl_faq_category.language.0">
                 <source>Language</source>

--- a/contao/languages/lv/tl_module.xlf
+++ b/contao/languages/lv/tl_module.xlf
@@ -33,6 +33,7 @@
             </trans-unit>
             <trans-unit id="tl_module.customLanguageText.1">
                 <source>Enter the page language as key and a replacement text as value.</source>
+                <target>Ievadiet lapas valodu kā atslēgu un aizstājējtekstu kā vērtību.</target>
             </trans-unit>
         </body>
     </file>

--- a/contao/languages/lv/tl_news_archive.xlf
+++ b/contao/languages/lv/tl_news_archive.xlf
@@ -11,6 +11,7 @@
             </trans-unit>
             <trans-unit id="tl_news_archive.master.2">
                 <source>This master has already been selected for the &quot;%s&quot; archive!</source>
+                <target>Šis meistars jau ir atlasīts &quot;%s&quot; arhīvam!</target>
             </trans-unit>
             <trans-unit id="tl_news_archive.language.0">
                 <source>Language</source>

--- a/contao/languages/lv/tl_user.xlf
+++ b/contao/languages/lv/tl_user.xlf
@@ -3,12 +3,15 @@
         <body>
             <trans-unit id="tl_user.pageLanguageLabels.0">
                 <source>Fallback page titles</source>
+                <target>Rezerves lapu nosaukumi</target>
             </trans-unit>
             <trans-unit id="tl_user.pageLanguageLabels.1">
                 <source>Select the root pages for which pages you want to show the fallback page title.</source>
+                <target>Atlasiet saknes lapas, kuru lapām vēlaties rādīt rezerves lapas virsrakstu.</target>
             </trans-unit>
             <trans-unit id="tl_user.changelanguage_legend">
                 <source>ChangeLanguage</source>
+                <target>ChangeLanguage</target>
             </trans-unit>
         </body>
     </file>

--- a/contao/languages/pl/default.xlf
+++ b/contao/languages/pl/default.xlf
@@ -3,6 +3,7 @@
         <body>
             <trans-unit id="MSC.duplicateMainLanguage">
                 <source>The selected page is already assigned to &quot;%s&quot; in the main language.</source>
+                <target>Wybrana strona jest już przypisana do &quot;%s&quot; w języku głównym.</target>
             </trans-unit>
             <trans-unit id="MSC.noMainLanguage">
                 <source>Main language missing</source>
@@ -22,6 +23,7 @@
             </trans-unit>
             <trans-unit id="MSC.gotoLanguage">
                 <source>Go to current page in %s</source>
+                <target>Przejdź do bieżącej strony w %s</target>
             </trans-unit>
         </body>
     </file>

--- a/contao/languages/pl/tl_calendar.xlf
+++ b/contao/languages/pl/tl_calendar.xlf
@@ -11,6 +11,7 @@
             </trans-unit>
             <trans-unit id="tl_calendar.master.2">
                 <source>This master has already been selected for the &quot;%s&quot; calendar!</source>
+                <target>Ten mistrz został już wybrany do &quot;%s&quot; kalendarza!</target>
             </trans-unit>
             <trans-unit id="tl_calendar.language.0">
                 <source>Language</source>

--- a/contao/languages/pl/tl_faq_category.xlf
+++ b/contao/languages/pl/tl_faq_category.xlf
@@ -11,6 +11,7 @@
             </trans-unit>
             <trans-unit id="tl_faq_category.master.2">
                 <source>This master has already been selected for the &quot;%s&quot; category!</source>
+                <target>Ten mistrz został już wybrany do kategorii &quot;%s&quot;!</target>
             </trans-unit>
             <trans-unit id="tl_faq_category.language.0">
                 <source>Language</source>

--- a/contao/languages/pl/tl_module.xlf
+++ b/contao/languages/pl/tl_module.xlf
@@ -32,6 +32,7 @@
             </trans-unit>
             <trans-unit id="tl_module.customLanguageText.1">
                 <source>Enter the page language as key and a replacement text as value.</source>
+                <target>Wprowadź język strony jako klucz i tekst zastępczy jako wartość.</target>
             </trans-unit>
         </body>
     </file>

--- a/contao/languages/pl/tl_news_archive.xlf
+++ b/contao/languages/pl/tl_news_archive.xlf
@@ -11,6 +11,7 @@
             </trans-unit>
             <trans-unit id="tl_news_archive.master.2">
                 <source>This master has already been selected for the &quot;%s&quot; archive!</source>
+                <target>Ten master został już wybrany do &quot;%s&quot; archiwum!</target>
             </trans-unit>
             <trans-unit id="tl_news_archive.language.0">
                 <source>Language</source>

--- a/contao/languages/pl/tl_user.xlf
+++ b/contao/languages/pl/tl_user.xlf
@@ -3,12 +3,15 @@
         <body>
             <trans-unit id="tl_user.pageLanguageLabels.0">
                 <source>Fallback page titles</source>
+                <target>Zastępcze tytuły stron</target>
             </trans-unit>
             <trans-unit id="tl_user.pageLanguageLabels.1">
                 <source>Select the root pages for which pages you want to show the fallback page title.</source>
+                <target>Wybierz strony główne, dla których ma być wyświetlany tytuł strony zastępczej.</target>
             </trans-unit>
             <trans-unit id="tl_user.changelanguage_legend">
                 <source>ChangeLanguage</source>
+                <target>ChangeLanguage</target>
             </trans-unit>
         </body>
     </file>

--- a/contao/languages/pt/default.xlf
+++ b/contao/languages/pt/default.xlf
@@ -23,6 +23,7 @@
             </trans-unit>
             <trans-unit id="MSC.gotoLanguage">
                 <source>Go to current page in %s</source>
+                <target>Ir para a página atual em %s</target>
             </trans-unit>
         </body>
     </file>

--- a/contao/languages/pt/tl_module.xlf
+++ b/contao/languages/pt/tl_module.xlf
@@ -32,6 +32,7 @@
             </trans-unit>
             <trans-unit id="tl_module.customLanguageText.1">
                 <source>Enter the page language as key and a replacement text as value.</source>
+                <target>Introduzir o idioma da página como chave e um texto de substituição como valor.</target>
             </trans-unit>
         </body>
     </file>

--- a/contao/languages/pt/tl_user.xlf
+++ b/contao/languages/pt/tl_user.xlf
@@ -3,12 +3,15 @@
         <body>
             <trans-unit id="tl_user.pageLanguageLabels.0">
                 <source>Fallback page titles</source>
+                <target>Títulos de página de recurso</target>
             </trans-unit>
             <trans-unit id="tl_user.pageLanguageLabels.1">
                 <source>Select the root pages for which pages you want to show the fallback page title.</source>
+                <target>Selecione as páginas de raiz para as quais pretende mostrar o título da página de recurso.</target>
             </trans-unit>
             <trans-unit id="tl_user.changelanguage_legend">
                 <source>ChangeLanguage</source>
+                <target>ChangeLanguage</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
This commit adds missing translation targets in multiple languages. The reason for this commit is that when I clear or warmup the cache in Contao 5+, it returns the following warning stating missing translations but also an error in the same file afterward.

```
[2024-09-17T10:11:30.119509+02:00] php.WARNING: Warning: Undefined array key "gotoLanguage" {"exception":"[object] (ErrorException(code: 0): Warning: Undefined array key \"gotoLanguage\" at /vendor/terminal42/contao-changelanguage/src/Navigation/NavigationFactory.php:56)"} {"request_uri":"/de/home","request_method":"GET"}
[2024-09-17T10:11:30.119835+02:00] request.CRITICAL: Uncaught PHP Exception TypeError: "sprintf(): Argument #1 ($format) must be of type string, null given" at NavigationFactory.php line 56 {"exception":"[object] (TypeError(code: 0): sprintf(): Argument #1 ($format) must be of type string, null given at /vendor/terminal42/contao-changelanguage/src/Navigation/NavigationFactory.php:56)"} {"request_uri":"/de/home","request_method":"GET"}
```

Once I added the translations, the error went away. I am unsure if this might also be able to be mitigated by changing line 56 to the following:

```