### PR TITLE
Fix AjaxToggle action causing a page reload

### DIFF
--- a/src/EventListener/DataContainer/MissingLanguageIconListener.php
+++ b/src/EventListener/DataContainer/MissingLanguageIconListener.php
@@ -241,7 +241,7 @@ class MissingLanguageIconListener implements ResetInterface
     private function generateLabelWithWarning(string $label, string $imgStyle = ''): string
     {
         return $label.\sprintf(
-            '<span style="padding-left:3px"><img src="%s" alt="%s" title="%s" style="%s"></span>',
+            '<span style="padding-left:3px"><img src="%s" data-icon="language-warning.png" data-icon-disabled="language-warning.png" alt="%s" title="%s" style="%s"></span>',
             'bundles/terminal42changelanguage/language-warning.png',
             $GLOBALS['TL_LANG']['MSC']['noMainLanguage'],
             $GLOBALS['TL_LANG']['MSC']['noMainLanguage'],


### PR DESCRIPTION
### Description

The AjaxToggle won't work due to the JavaScript execution stopping due to an error, thus reloading the page completely when publishing / unpublishing.

This happens due to the "missingLanguageIcon" that is found as a row image:
https://github.com/contao/contao/blob/44c2193f42f288310e155b5533d1c5a27a54995a/core-bundle/assets/scripts/core.js#L364
