### PR TITLE
Consider pagemounts within the language label visibility

### DIFF
--- a/src/EventListener/DataContainer/UserLabelsListener.php
+++ b/src/EventListener/DataContainer/UserLabelsListener.php
@@ -4,14 +4,20 @@ declare(strict_types=1);
 
 namespace Terminal42\ChangeLanguage\EventListener\DataContainer;
 
+use Contao\BackendUser;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
+use Contao\User;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use Symfony\Bundle\SecurityBundle\Security;
 
 #[AsCallback('tl_user', 'fields.pageLanguageLabels.options')]
 class UserLabelsListener
 {
-    public function __construct(private readonly Connection $connection)
-    {
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly Security $security,
+    ) {
     }
 
     /**
@@ -19,6 +25,25 @@ class UserLabelsListener
      */
     public function __invoke(): array
     {
-        return $this->connection->fetchAllKeyValue("SELECT id, title FROM tl_page WHERE type='root' AND (fallback='' OR languageRoot!=0) ORDER BY pid, sorting");
+        /** @var User $user */
+        $user = $this->security->getUser();
+
+        if (!$user instanceof BackendUser) {
+            return [];
+        }
+
+        if ($user->isAdmin) {
+            return $this->connection->fetchAllKeyValue("SELECT id, title FROM tl_page WHERE type='root' AND (fallback='' OR languageRoot!=0) ORDER BY pid, sorting");
+        }
+
+        if (empty($user->pagemounts)) {
+            return [];
+        }
+
+        return $this->connection->fetchAllKeyValue(
+            "SELECT id, title FROM tl_page WHERE type='root' AND (fallback='' OR languageRoot!=0) AND id IN (?) ORDER BY pid, sorting",
+            [$user->pagemounts],
+            [ArrayParameterType::INTEGER]
+        );
     }
 }


### PR DESCRIPTION
### Description

This PR updates the options callback for the `pageLanguageLabels` shown within the user settings to only show the pagemounts for non-admins.

Imo users should not be able to see other pages within the CMS if they do not have the pagemount / rights for it.