### PR TITLE
Fix version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^8.1",
         "contao/core-bundle": "^5.3",
-        "league/uri-components": "^7.0",
+        "league/uri-components": "^7.6",
         "doctrine/dbal": "^3.6 || ^4",
         "psr/container": "^1 || ^2",
         "symfony/config": "^6.4 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^8.1",
         "contao/core-bundle": "^5.3",
-        "league/uri-components": "^2.0 || ^7.0",
+        "league/uri-components": "^7.0",
         "doctrine/dbal": "^3.6 || ^4",
         "psr/container": "^1 || ^2",
         "symfony/config": "^6.4 || ^7.0",


### PR DESCRIPTION
The `ParentChildViewListener` uses [`League\Uri\Modifier`](https://github.com/thephpleague/uri-components/blob/master/Modifier.php), which is available in `^7.0`, but not in [`2.4.x`](https://github.com/thephpleague/uri-components/blob/2.4.x/Modifier.php), which makes that version incompatible.

```
composer why league/uri-components
terminal42/contao-changelanguage 3.8.0 requires league/uri-components (^2.0 || ^7.0) 
```

<img width="1072" height="642" alt="Bildschirmfoto 2026-04-28 um 11 36 00" src="https://github.com/user-attachments/assets/65ddc3e4-d920-4c10-b62d-603542ba91df" />

